### PR TITLE
feat: Firestoreサービス層とカスタムフック追加

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useProjects, useProject, useProjectStats, createProject } from './useProjects'
+export { useCustomers, useCustomer, createCustomer } from './useCustomers'

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -1,0 +1,102 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { Customer } from '@/types'
+import {
+  getCustomers,
+  getCustomerById,
+  createDocument,
+  updateDocument,
+  deleteDocument,
+  COLLECTIONS,
+} from '@/lib/firestore'
+
+interface UseCustomersReturn {
+  customers: Customer[]
+  loading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export function useCustomers(): UseCustomersReturn {
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchCustomers = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await getCustomers()
+      setCustomers(data)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch customers'))
+      setCustomers([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchCustomers()
+  }, [fetchCustomers])
+
+  return { customers, loading, error, refetch: fetchCustomers }
+}
+
+interface UseCustomerReturn {
+  customer: Customer | null
+  loading: boolean
+  error: Error | null
+  update: (data: Partial<Customer>) => Promise<void>
+  remove: () => Promise<void>
+}
+
+export function useCustomer(id: string): UseCustomerReturn {
+  const [customer, setCustomer] = useState<Customer | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    async function fetchCustomer() {
+      try {
+        setLoading(true)
+        setError(null)
+        const data = await getCustomerById(id)
+        setCustomer(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch customer'))
+        setCustomer(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (id) {
+      fetchCustomer()
+    }
+  }, [id])
+
+  const update = useCallback(
+    async (data: Partial<Customer>) => {
+      if (!id) return
+      await updateDocument(COLLECTIONS.CUSTOMERS, id, data)
+      setCustomer((prev) => (prev ? { ...prev, ...data } : null))
+    },
+    [id]
+  )
+
+  const remove = useCallback(async () => {
+    if (!id) return
+    await deleteDocument(COLLECTIONS.CUSTOMERS, id)
+    setCustomer(null)
+  }, [id])
+
+  return { customer, loading, error, update, remove }
+}
+
+export async function createCustomer(
+  data: Omit<Customer, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<string> {
+  return createDocument(COLLECTIONS.CUSTOMERS, data)
+}

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { Project } from '@/types'
+import {
+  getProjects,
+  getProjectStats,
+  getDocument,
+  createDocument,
+  updateDocument,
+  deleteDocument,
+  COLLECTIONS,
+} from '@/lib/firestore'
+
+interface UseProjectsOptions {
+  status?: string
+  phase?: string
+  limitCount?: number
+}
+
+interface UseProjectsReturn {
+  projects: Project[]
+  loading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export function useProjects(options?: UseProjectsOptions): UseProjectsReturn {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchProjects = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await getProjects(options)
+      setProjects(data)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch projects'))
+      setProjects([])
+    } finally {
+      setLoading(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options?.status, options?.phase, options?.limitCount])
+
+  useEffect(() => {
+    fetchProjects()
+  }, [fetchProjects])
+
+  return { projects, loading, error, refetch: fetchProjects }
+}
+
+interface ProjectStats {
+  total: number
+  byStatus: Record<string, number>
+  byPhase: Record<string, number>
+}
+
+interface UseProjectStatsReturn {
+  stats: ProjectStats | null
+  loading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export function useProjectStats(): UseProjectStatsReturn {
+  const [stats, setStats] = useState<ProjectStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchStats = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await getProjectStats()
+      setStats(data)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch stats'))
+      setStats(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  return { stats, loading, error, refetch: fetchStats }
+}
+
+interface UseProjectReturn {
+  project: Project | null
+  loading: boolean
+  error: Error | null
+  update: (data: Partial<Project>) => Promise<void>
+  remove: () => Promise<void>
+}
+
+export function useProject(id: string): UseProjectReturn {
+  const [project, setProject] = useState<Project | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    async function fetchProject() {
+      try {
+        setLoading(true)
+        setError(null)
+        const data = await getDocument<Project>(COLLECTIONS.PROJECTS, id)
+        setProject(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch project'))
+        setProject(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (id) {
+      fetchProject()
+    }
+  }, [id])
+
+  const update = useCallback(
+    async (data: Partial<Project>) => {
+      if (!id) return
+      await updateDocument(COLLECTIONS.PROJECTS, id, data)
+      setProject((prev) => (prev ? { ...prev, ...data } : null))
+    },
+    [id]
+  )
+
+  const remove = useCallback(async () => {
+    if (!id) return
+    await deleteDocument(COLLECTIONS.PROJECTS, id)
+    setProject(null)
+  }, [id])
+
+  return { project, loading, error, update, remove }
+}
+
+export async function createProject(
+  data: Omit<Project, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<string> {
+  return createDocument(COLLECTIONS.PROJECTS, data)
+}

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,0 +1,172 @@
+import {
+  collection,
+  doc,
+  getDocs,
+  getDoc,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  limit,
+  Timestamp,
+  DocumentData,
+  QueryConstraint,
+} from 'firebase/firestore'
+import { db } from './firebase'
+import type { Project, Customer, Estimate, User } from '@/types'
+
+// Collection names
+export const COLLECTIONS = {
+  PROJECTS: 'projects',
+  CUSTOMERS: 'customers',
+  ESTIMATES: 'estimates',
+  USERS: 'users',
+  DRAWINGS: 'drawings',
+  PRODUCTION_PROCESSES: 'productionProcesses',
+  MATERIALS: 'materials',
+  CONSTRUCTION_SCHEDULES: 'constructionSchedules',
+  INSPECTIONS: 'inspections',
+} as const
+
+// Date conversion helpers
+const toDate = (timestamp: Timestamp | Date | undefined): Date | undefined => {
+  if (!timestamp) return undefined
+  if (timestamp instanceof Timestamp) return timestamp.toDate()
+  return timestamp
+}
+
+const toTimestamp = (date: Date | undefined): Timestamp | undefined => {
+  if (!date) return undefined
+  return Timestamp.fromDate(date)
+}
+
+// Generic CRUD operations
+export async function getDocuments<T>(
+  collectionName: string,
+  ...queryConstraints: QueryConstraint[]
+): Promise<T[]> {
+  const q = query(collection(db, collectionName), ...queryConstraints)
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  })) as T[]
+}
+
+export async function getDocument<T>(
+  collectionName: string,
+  docId: string
+): Promise<T | null> {
+  const docRef = doc(db, collectionName, docId)
+  const snapshot = await getDoc(docRef)
+  if (!snapshot.exists()) return null
+  return { id: snapshot.id, ...snapshot.data() } as T
+}
+
+export async function createDocument(
+  collectionName: string,
+  data: Record<string, unknown>
+): Promise<string> {
+  const docRef = await addDoc(collection(db, collectionName), {
+    ...data,
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  })
+  return docRef.id
+}
+
+export async function updateDocument(
+  collectionName: string,
+  docId: string,
+  data: Record<string, unknown>
+): Promise<void> {
+  const docRef = doc(db, collectionName, docId)
+  await updateDoc(docRef, {
+    ...data,
+    updatedAt: Timestamp.now(),
+  })
+}
+
+export async function deleteDocument(
+  collectionName: string,
+  docId: string
+): Promise<void> {
+  const docRef = doc(db, collectionName, docId)
+  await deleteDoc(docRef)
+}
+
+// Project specific operations
+export async function getProjects(options?: {
+  status?: string
+  phase?: string
+  limitCount?: number
+}): Promise<Project[]> {
+  const constraints: QueryConstraint[] = []
+
+  if (options?.status) {
+    constraints.push(where('status', '==', options.status))
+  }
+  if (options?.phase) {
+    constraints.push(where('currentPhase', '==', options.phase))
+  }
+  constraints.push(orderBy('updatedAt', 'desc'))
+  if (options?.limitCount) {
+    constraints.push(limit(options.limitCount))
+  }
+
+  return getDocuments<Project>(COLLECTIONS.PROJECTS, ...constraints)
+}
+
+export async function getProjectStats(): Promise<{
+  total: number
+  byStatus: Record<string, number>
+  byPhase: Record<string, number>
+}> {
+  const projects = await getDocuments<Project>(COLLECTIONS.PROJECTS)
+
+  const byStatus: Record<string, number> = {}
+  const byPhase: Record<string, number> = {}
+
+  projects.forEach((project) => {
+    byStatus[project.status] = (byStatus[project.status] || 0) + 1
+    byPhase[project.currentPhase] = (byPhase[project.currentPhase] || 0) + 1
+  })
+
+  return {
+    total: projects.length,
+    byStatus,
+    byPhase,
+  }
+}
+
+// Customer operations
+export async function getCustomers(): Promise<Customer[]> {
+  return getDocuments<Customer>(
+    COLLECTIONS.CUSTOMERS,
+    orderBy('companyName', 'asc')
+  )
+}
+
+export async function getCustomerById(id: string): Promise<Customer | null> {
+  return getDocument<Customer>(COLLECTIONS.CUSTOMERS, id)
+}
+
+// User operations
+export async function getUsers(): Promise<User[]> {
+  return getDocuments<User>(COLLECTIONS.USERS, orderBy('name', 'asc'))
+}
+
+export async function getUserById(id: string): Promise<User | null> {
+  return getDocument<User>(COLLECTIONS.USERS, id)
+}
+
+// Estimate operations
+export async function getEstimatesByProject(projectId: string): Promise<Estimate[]> {
+  return getDocuments<Estimate>(
+    COLLECTIONS.ESTIMATES,
+    where('projectId', '==', projectId),
+    orderBy('version', 'desc')
+  )
+}


### PR DESCRIPTION
## Summary
- Firestoreの汎用CRUD操作関数を追加
- プロジェクト用カスタムフック（useProjects, useProject, useProjectStats）
- 顧客用カスタムフック（useCustomers, useCustomer）
- 型安全なデータ操作

## 追加ファイル
| ファイル | 説明 |
|---------|------|
| `src/lib/firestore.ts` | Firestore CRUD操作 |
| `src/hooks/useProjects.ts` | プロジェクトフック |
| `src/hooks/useCustomers.ts` | 顧客フック |
| `src/hooks/index.ts` | エクスポート |

## Test plan
- [x] ESLint チェック通過
- [x] TypeScript ビルド成功
- [ ] Firestoreとの接続確認
- [ ] データ取得・作成テスト

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)